### PR TITLE
Merge conflict markers left in.

### DIFF
--- a/includes/class.settings.php
+++ b/includes/class.settings.php
@@ -414,15 +414,8 @@ class cnRegisterSettings
 			'page_hook' => $settings,
 			'tab'       => 'display',
 			'section'   => 'connections_display_single',
-<<<<<<< HEAD
-			'title'     => '',
-			'desc'      => __('Display a single entry using the active template based on entry type.
-				For example, if the entry is an organization it will be displayed using the template
-				that is activated for the "Organization" template type found on the Connections : Templates admin page.', 'connections'),
-=======
 			'title'     => __( '', 'connections' ),
 			'desc'      => __( 'Display a single entry using the active template based on entry type. For example, if the entry is an organization it will be displayed using the template that is activated for the "Organization" template type found on the Connections : Templates admin page.', 'connections' ),
->>>>>>> fxbenard-develop
 			'help'      => '',
 			'type'      => 'checkbox',
 			'default'   => 0


### PR DESCRIPTION
Latest update to Connections (Version 0.7.6.5 ) causes a 500 error caused by the merge conflict markers left in the class.settings.php file, line 417. This pull request clears out those markers and ensures that connections loads as per usual. 
